### PR TITLE
CF-288: Add 'tooltip' style confirmation for delete

### DIFF
--- a/assets/stylesheets/coefficient/dropdown-menu.sass
+++ b/assets/stylesheets/coefficient/dropdown-menu.sass
@@ -37,3 +37,37 @@
           padding-left: 32px
         list-style: none
       padding: 0
+
+// Tooltip style
+.dropdown-tooltip
+  position: relative
+.dropdown-menu
+  &.tooltip-style
+    top: 32px
+    left: -102px
+    width: 240px
+    text-align: center
+    font-size: 11px
+    background: $black
+    color: $white
+    border-radius: 4px
+    // Creating CSS Arrow below
+    &:after, &:before
+      bottom: 100%
+      left: 50%
+      border: solid transparent
+      content: " "
+      height: 0
+      width: 0
+      position: absolute
+      pointer-events: none
+    &:after
+      border-color: rgba(250, 250, 250, 0)
+      border-bottom-color: $black
+      border-width: 8px
+      margin-left: -8px
+    &:before
+      border-color: rgba(218, 218, 218, 0)
+      border-bottom-color: $black
+      border-width: 8px
+      margin-left: -8px

--- a/localdev/homepage.html.ejs
+++ b/localdev/homepage.html.ejs
@@ -96,7 +96,16 @@
         <div class="action-header-left">
           <button type="button" id="print-button" class="btn btn-default"><i class="fa fa-print"></i></button>
           <button type="button" id="note-emailed" class="btn btn-default"><i class="fa fa-envelope"></i></button>
-          <button type="button" id="note-deleted" class="btn btn-default"><i class="fa fa-trash-o"></i></button>
+          <span class="dropdown-tooltip">
+            <button type="button" data-toggle="dropdown" class="btn btn-default"><i class="fa fa-trash-o"></i></button>
+            <ul class="dropdown-menu tooltip-style">
+              <li>
+                <p>Are you sure you want to delete?</p>
+                <button type="button" class="btn btn-xs btn-default">Cancel</button>
+                <button type="button" id="note-deleted" class="btn btn-xs btn-default">Delete</button>
+              </li>
+            </ul>
+          </span>
         </div>
       </div>
       <div class="cl-mcont">


### PR DESCRIPTION
This commit adds the tooltip style confirmation functionality and
styling.