### PR TITLE
CF-445: Move 'clickable' placeholder styling to location only

### DIFF
--- a/assets/stylesheets/coefficient/froala.sass
+++ b/assets/stylesheets/coefficient/froala.sass
@@ -6,15 +6,6 @@
   min-height: initial !important // Overriding Froala default
   &.f-placeholder
     + span.fr-placeholder
-      color: $link-color
-      text-decoration: underline
+      color: #999
+      top: 0
       padding-left: 0
-      -webkit-font-smoothing: initial
-  &.f-placeholder:hover
-    cursor: pointer
-    + span.fr-placeholder
-      color: $link-hover
-  &.f-placeholder:focus
-    cursor: text
-    + span.fr-placeholder
-      color: transparent

--- a/assets/stylesheets/coefficient/notes.sass
+++ b/assets/stylesheets/coefficient/notes.sass
@@ -44,6 +44,19 @@
           cursor: text
     .fr-placeholder
       line-height: 1
+      color: $link-color
+      text-decoration: underline
+      padding-left: 2px
+      white-space: nowrap
+      -webkit-font-smoothing: initial
+    .f-placeholder:hover
+      cursor: pointer
+      + span.fr-placeholder
+        color: $link-hover
+    .f-placeholder:focus
+      cursor: text
+      + span.fr-placeholder
+        color: transparent
   .location-selector
     display: block
   .datepicker

--- a/assets/stylesheets/coefficient/responsive.sass
+++ b/assets/stylesheets/coefficient/responsive.sass
@@ -254,6 +254,8 @@
       position: fixed
       width: 279px
       top: 170px
+      padding-bottom: 2px
+      border-bottom: 1px solid #E8E8E8
     #aside-items
       position: fixed
       width: 279px


### PR DESCRIPTION
This commit fixes the notes content area placeholder looking like a link