### PR TITLE
CF-516: Fix page headers styling

### DIFF
--- a/assets/javascripts/localdev/general.js
+++ b/assets/javascripts/localdev/general.js
@@ -1418,7 +1418,6 @@ var App = function () {
           var asideW = $("#page-aside").width();
 
           $("#fixed-action-header").css("left", navW + asideW);
-          $(".page-head").css("left", navW);
         }
 
         $(window).resize(function() {

--- a/assets/stylesheets/coefficient/layout.sass
+++ b/assets/stylesheets/coefficient/layout.sass
@@ -140,6 +140,7 @@ ol
   padding: 20px 25px
   position: fixed
   right: 0
+  left: 216px
   z-index: 5
   + .cl-mcont
     padding-top: 85px
@@ -150,6 +151,10 @@ ol
     background: none repeat scroll 0 0 rgba(0, 0, 0, 0)
     margin-bottom: 0
     padding: 4px
+
+.sb-collapsed
+  .page-head
+    left: 55px
 
 /* Widgets */
 .widget-block


### PR DESCRIPTION
This commit removes JS requirements for fixed page headers styling
and uses CSS instead..