### PR TITLE
CF-494: Add disabled button and tooltip markup

### DIFF
--- a/assets/stylesheets/coefficient/buttons.sass
+++ b/assets/stylesheets/coefficient/buttons.sass
@@ -60,6 +60,11 @@ $buttons: (default: ($white, #cccccc, #e6e6e6, #adadad), primary: ($primary, #36
   &.btn-default
     background: $white
 
+// Disabled Button
+// This is used if a disabled button has a tooltip since disabled buttons do not show tooltips by default
+.disabled-button-wrapper
+  display: inline-block
+
 
 /* Specific icons size */
 .btn-xs

--- a/localdev/homepage.html.ejs
+++ b/localdev/homepage.html.ejs
@@ -99,6 +99,10 @@
         <div class="action-header-left">
           <button type="button" id="print-button" class="btn btn-default"><i class="fa fa-print"></i></button>
           <button type="button" id="note-emailed" class="btn btn-default"><i class="fa fa-envelope"></i></button>
+          <!-- Disabled button example (if there are action items on page) -->
+          <!-- <div class="disabled-button-wrapper" data-toggle="tooltip" data-placement="bottom" title="Notes with action items cannot be deleted.">
+            <button type="button" id="note-deleted" class="btn btn-default" disabled><i class="fa fa-trash-o"></i></button>
+          </div> -->
           <button type="button" id="note-deleted" class="btn btn-default"><i class="fa fa-trash-o"></i></button>
         </div>
       </div>


### PR DESCRIPTION
This commit accounts for when a note is not able to be deleted -
the delete button should be 'disabled' instead of removed and a
tooltip should appear on hover.