### PR TITLE
CF-499: Update success and error state for progress buttons

### DIFF
--- a/assets/stylesheets/coefficient/buttons.sass
+++ b/assets/stylesheets/coefficient/buttons.sass
@@ -100,6 +100,14 @@ $buttons: (default: ($white, #cccccc, #e6e6e6, #adadad), primary: ($primary, #36
 .progress-button .content::after
   content: "\f071" /* Alert for error */
 
+.progress-button.state-success
+  background: $success
+  border: 1px solid #65ca65
+
+.progress-button.state-error
+  background: $danger
+  border: 1px solid #ca452e
+
 .progress-button.state-success .content::before,
 .progress-button.state-error .content::after
   opacity: 1
@@ -109,12 +117,12 @@ $buttons: (default: ($white, #cccccc, #e6e6e6, #adadad), primary: ($primary, #36
   transition: none !important
 
 .progress-button .progress
-  background: #362C66
+  background: $link-hover
 
 .progress-button .progress-inner
   position: absolute
   left: 0
-  background: #362C66
+  background: $link-hover
 
 .progress-button[data-horizontal] .progress-inner
   top: 0


### PR DESCRIPTION
This commit updates the success and error state of progress buttons
to be our predefined $success and $danger colors, respectively, for
more obvious feedback to user.