### PR TITLE
CF-585: Update non rich text styling

### DIFF
--- a/assets/stylesheets/coefficient/notes.sass
+++ b/assets/stylesheets/coefficient/notes.sass
@@ -141,10 +141,15 @@
   padding: 0
   border: 0
   box-shadow: none
-  &:focus
-    padding: 6px 8px
-    box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075), 0 0 8px rgba(102, 175, 233, 0.6)
-    border: 1px solid #2598F9
+
+#note-title
+  font-size: 24px
+  font-weight: 300
+
+#note-content
+  height: 18px
+  margin-bottom: 10px
+  resize: none
 
 #set-location
   color: $link-color


### PR DESCRIPTION
Removing borders around note title and content area now that the
content area is able to resize as you type.