### PR TITLE
CF-610: Markup for audit reporting drilldown

### DIFF
--- a/assets/stylesheets/coefficient/audit-reporting.sass
+++ b/assets/stylesheets/coefficient/audit-reporting.sass
@@ -11,7 +11,7 @@
 #audit-report-tracking
   display: table
   width: 100%
-  padding: 15px 10px 5px 10px
+  padding: 25px 10px 10px 10px
 
   #percent-reporting
     display: table-cell

--- a/assets/stylesheets/coefficient/dropdown-menu.sass
+++ b/assets/stylesheets/coefficient/dropdown-menu.sass
@@ -19,6 +19,8 @@
   &.full-width
     width: 100%
     margin-top: -11px
+  .divider
+    margin: 5px 0
 
 .dropdown-header
   color: #2083D6

--- a/localdev/auditreportarea.html.ejs
+++ b/localdev/auditreportarea.html.ejs
@@ -39,7 +39,9 @@
         <h2>Retail Quality Inspection</h2>
         <ol class="breadcrumb">
           <li><a href="audits.html">Audits</a></li>
-          <li class="active">Retail Quality Inspection</li>
+          <li><a href="auditreport.html">Retail Quality Inspection</a></li>
+          <li><a href="auditreportregion.html">IER</a></li>
+          <li class="active">ATL</li>
         </ol>
       </div>
 
@@ -58,37 +60,47 @@
           <div class="col-sm-8">
             <div class="block-flat">
               <div class="header">
-                <h3>National Reporting</h3>
+                <h3>ATL Reporting</h3>
               </div>
               <div class="content">
                 <div id="audit-report-tracking">
-                  <div id="percent-reporting">50%</div>
+                  <div id="percent-reporting">42%</div>
                   <div id="reporting-progress-bar">
                     <div class="progress">
-                      <div class="progress-bar progress-bar-info" style="width: 50%"></div>
+                      <div class="progress-bar progress-bar-info" style="width: 42%"></div>
                     </div>
-                    (150 of 300 Locations Reporting)
+                    (28 of 66 Locations Reporting)
                   </div>
                 </div>
 
                 <table id="reporting-table" class="datatable">
                   <thead>
                     <tr>
-                      <th>Region <i class="fa fa-sort-down active"></i></th>
+                      <th>District <i class="fa fa-sort-down active"></i></th>
                       <th class="text-center">Average Score <i class="fa fa-sort"></i></th>
                       <th class="text-center">% Passing <i class="fa fa-sort"></i></th>
                     </tr>
                   </thead>
                   <tbody>
                     <tr>
-                      <td><a href="auditreportregion.html">IER</a></td>
-                      <td class="text-center"><a href="auditreportregion.html">87%</a></td>
-                      <td class="text-center"><a href="auditreportregion.html">47%</a></td>
+                      <td><a href="auditreportdistrict.html">11</a></td>
+                      <td class="text-center"><a href="auditreportdistrict.html">83%</a></td>
+                      <td class="text-center"><a href="auditreportdistrict.html">36%</a></td>
                     </tr>
                     <tr>
-                      <td><a href="auditreportregion.html">IWR</a></td>
-                      <td class="text-center"><a href="auditreportregion.html">84%</a></td>
-                      <td class="text-center"><a href="auditreportregion.html">54%</a></td>
+                      <td><a href="auditreportdistrict.html">12</a></td>
+                      <td class="text-center"><a href="auditreportdistrict.html">84%</a></td>
+                      <td class="text-center"><a href="auditreportdistrict.html">54%</a></td>
+                    </tr>
+                    <tr>
+                      <td><a href="auditreportdistrict.html">13</a></td>
+                      <td class="text-center"><a href="auditreportdistrict.html">74%</a></td>
+                      <td class="text-center"><a href="auditreportdistrict.html">48%</a></td>
+                    </tr>
+                    <tr>
+                      <td><a href="auditreportdistrict.html">14</a></td>
+                      <td class="text-center"><a href="auditreportdistrict.html">92%</a></td>
+                      <td class="text-center"><a href="auditreportdistrict.html">40%</a></td>
                     </tr>
                   </tbody>
                 </table>

--- a/localdev/auditreportdistrict.html.ejs
+++ b/localdev/auditreportdistrict.html.ejs
@@ -39,7 +39,10 @@
         <h2>Retail Quality Inspection</h2>
         <ol class="breadcrumb">
           <li><a href="audits.html">Audits</a></li>
-          <li class="active">Retail Quality Inspection</li>
+          <li><a href="auditreport.html">Retail Quality Inspection</a></li>
+          <li><a href="auditreportregion.html">IER</a></li>
+          <li><a href="auditreportarea.html">ATL</a></li>
+          <li class="active">11</li>
         </ol>
       </div>
 
@@ -58,37 +61,72 @@
           <div class="col-sm-8">
             <div class="block-flat">
               <div class="header">
-                <h3>National Reporting</h3>
+                <h3>District 11 Reporting</h3>
               </div>
               <div class="content">
                 <div id="audit-report-tracking">
-                  <div id="percent-reporting">50%</div>
+                  <div id="percent-reporting">33%</div>
                   <div id="reporting-progress-bar">
                     <div class="progress">
-                      <div class="progress-bar progress-bar-info" style="width: 50%"></div>
+                      <div class="progress-bar progress-bar-info" style="width: 33%"></div>
                     </div>
-                    (150 of 300 Locations Reporting)
+                    (3 of 9 Locations Reporting)
                   </div>
                 </div>
 
                 <table id="reporting-table" class="datatable">
                   <thead>
                     <tr>
-                      <th>Region <i class="fa fa-sort-down active"></i></th>
-                      <th class="text-center">Average Score <i class="fa fa-sort"></i></th>
-                      <th class="text-center">% Passing <i class="fa fa-sort"></i></th>
+                      <th>Dealership <i class="fa fa-sort-down active"></i></th>
+                      <th class="text-center">Score <i class="fa fa-sort"></i></th>
+                      <th class="text-right">Date Reported <i class="fa fa-sort"></i></th>
                     </tr>
                   </thead>
                   <tbody>
-                    <tr>
-                      <td><a href="auditreportregion.html">IER</a></td>
-                      <td class="text-center"><a href="auditreportregion.html">87%</a></td>
-                      <td class="text-center"><a href="auditreportregion.html">47%</a></td>
+                    <tr class="disabled">
+                      <td>Bonita Springs Infiniti - 75033</td>
+                      <td class="text-center">87%</td>
+                      <td class="text-right">June 07</td>
                     </tr>
-                    <tr>
-                      <td><a href="auditreportregion.html">IWR</a></td>
-                      <td class="text-center"><a href="auditreportregion.html">84%</a></td>
-                      <td class="text-center"><a href="auditreportregion.html">54%</a></td>
+                    <tr class="disabled">
+                      <td>Fort Myers Infiniti - 71529</td>
+                      <td class="text-center">84%</td>
+                      <td class="text-right">June 10</td>
+                    </tr>
+                    <tr class="disabled">
+                      <td>Infinity of Coconut Creek - 70512</td>
+                      <td class="text-center">0%</td>
+                      <td class="text-right">Not Reported</td>
+                    </tr>
+                    <tr class="disabled">
+                      <td>Infiniti of Palm Beaches - 71050</td>
+                      <td class="text-center">0%</td>
+                      <td class="text-right">Not Reported</td>
+                    </tr>
+                    <tr class="disabled">
+                      <td>Infiniti Stuart - 70577</td>
+                      <td class="text-center">0%</td>
+                      <td class="text-right">Not Reported</td>
+                    </tr>
+                    <tr class="disabled">
+                      <td>Lauderdale Infiniti - 71527</td>
+                      <td class="text-center">92%</td>
+                      <td class="text-right">June 13</td>
+                    </tr>
+                    <tr class="disabled">
+                      <td>Sawgrass Infiniti - 73051</td>
+                      <td class="text-center">0%</td>
+                      <td class="text-right">Not Reported</td>
+                    </tr>
+                    <tr class="disabled">
+                      <td>South Motors Infiniti - 70053</td>
+                      <td class="text-center">0%</td>
+                      <td class="text-right">Not Reported</td>
+                    </tr>
+                    <tr class="disabled">
+                      <td>Warren Henry Infiniti - 70052</td>
+                      <td class="text-center">0%</td>
+                      <td class="text-right">Not Reported</td>
                     </tr>
                   </tbody>
                 </table>

--- a/localdev/auditreportregion.html.ejs
+++ b/localdev/auditreportregion.html.ejs
@@ -39,7 +39,8 @@
         <h2>Retail Quality Inspection</h2>
         <ol class="breadcrumb">
           <li><a href="audits.html">Audits</a></li>
-          <li class="active">Retail Quality Inspection</li>
+          <li><a href="auditreport.html">Retail Quality Inspection</a></li>
+          <li class="active">IER</li>
         </ol>
       </div>
 
@@ -58,37 +59,42 @@
           <div class="col-sm-8">
             <div class="block-flat">
               <div class="header">
-                <h3>National Reporting</h3>
+                <h3>IER Reporting</h3>
               </div>
               <div class="content">
                 <div id="audit-report-tracking">
-                  <div id="percent-reporting">50%</div>
+                  <div id="percent-reporting">47%</div>
                   <div id="reporting-progress-bar">
                     <div class="progress">
-                      <div class="progress-bar progress-bar-info" style="width: 50%"></div>
+                      <div class="progress-bar progress-bar-info" style="width: 47%"></div>
                     </div>
-                    (150 of 300 Locations Reporting)
+                    (61 of 130 Locations Reporting)
                   </div>
                 </div>
 
                 <table id="reporting-table" class="datatable">
                   <thead>
                     <tr>
-                      <th>Region <i class="fa fa-sort-down active"></i></th>
+                      <th>Area <i class="fa fa-sort-down active"></i></th>
                       <th class="text-center">Average Score <i class="fa fa-sort"></i></th>
                       <th class="text-center">% Passing <i class="fa fa-sort"></i></th>
                     </tr>
                   </thead>
                   <tbody>
                     <tr>
-                      <td><a href="auditreportregion.html">IER</a></td>
-                      <td class="text-center"><a href="auditreportregion.html">87%</a></td>
-                      <td class="text-center"><a href="auditreportregion.html">47%</a></td>
+                      <td><a href="auditreportarea.html">ATL</a></td>
+                      <td class="text-center"><a href="auditreportarea.html">87%</a></td>
+                      <td class="text-center"><a href="auditreportarea.html">42%</a></td>
                     </tr>
                     <tr>
-                      <td><a href="auditreportregion.html">IWR</a></td>
-                      <td class="text-center"><a href="auditreportregion.html">84%</a></td>
-                      <td class="text-center"><a href="auditreportregion.html">54%</a></td>
+                      <td><a href="auditreportarea.html">CHI</a></td>
+                      <td class="text-center"><a href="auditreportarea.html">94%</a></td>
+                      <td class="text-center"><a href="auditreportarea.html">54%</a></td>
+                    </tr>
+                    <tr>
+                      <td><a href="auditreportarea.html">NY</a></td>
+                      <td class="text-center"><a href="auditreportarea.html">82%</a></td>
+                      <td class="text-center"><a href="auditreportarea.html">48%</a></td>
                     </tr>
                   </tbody>
                 </table>


### PR DESCRIPTION
Adding markup for the drilldown to fake functionality of how the reporting table would work as well as show the district level which does not have clickable rows.